### PR TITLE
Add pause capability to freehand editing

### DIFF
--- a/freehandeditingtool.py
+++ b/freehandeditingtool.py
@@ -16,10 +16,10 @@ class FreehandEditingTool(QgsMapTool):
         self.rb = None
         self.mCtrl = None
         self.drawing = False
-        self.mPause = False
         self.ignoreclick = False
         self.canvas.keyPressed.connect(self.keyPressEvent)
         self.canvas.keyReleased.connect(self.keyReleaseEvent)
+        #our own fancy cursor
         self.cursor = QCursor(QPixmap(["16 16 3 1",
                                        "      c None",
                                        ".     c #FF0000",
@@ -42,8 +42,6 @@ class FreehandEditingTool(QgsMapTool):
                                        "       +.+      "]))
 
     def keyPressEvent(self, event):
-        dx = self.canvas.extent().width() / 4
-        dy = self.canvas.extent().height() / 4
         if event.key() == Qt.Key_Control:
             self.mCtrl = True
         elif event.key() == Qt.Key_Space and self.drawing:
@@ -114,7 +112,6 @@ class FreehandEditingTool(QgsMapTool):
         self.drawing = False
         if not self.rb:
             return
-
         if self.rb.numberOfVertices() > 2:
             geom = self.rb.asGeometry()
             self.rbFinished.emit(geom)


### PR DESCRIPTION

While the user is drawing a line, the user can press the space bar.  The rubber band and the mouse are now decoupled, so that the user can pan the map with keyboard or mouse, check on something in another part of the map or engage in any other activity.  When the user is ready to resume drawing, the user positions the mouse where the line should resume (close to the current endpoint, presumably) and then hits the space bar again.  Drawing of the line resumes.

This fixes the problem that freehandEditing does not allow for panning the map with the arrow keys while drawing the line.

A side effect is, once you resume drawing, the left mouse button no longer has to be pressed to continue the line.  It can be, but its not necessary.  The line ends when the mouse is released, so either holding the mouse button and releasing, as in current use, or cheating and just clicking once at the end of the line, will work.  I think this is pleasant feature not bug.  I can imagine it making for instance working with a trackpad possible/easier.

It works by setting self.ignoreclicks from the keyPressedEvent.

Also, the keyPressedEvent and keyReleasedEvent weren't being triggered.  I connected those slots  from the canvas signals in the constructor.

Adding a mouse click pause to enable use of touchscreen/stylus setups without keyboards would be the next thing to do, but I don't yet have a setup to test.  Which mouse click to  use is probably something that should be configurable from a menu.  I am planning on getting such a setup and would be willing to add such functionality at that time.